### PR TITLE
lines 59,66: encodestring --> encodebytes

### DIFF
--- a/mturk/mturk.py
+++ b/mturk/mturk.py
@@ -56,14 +56,14 @@ class MechanicalTurk(object):
 
 	def _generate_signature_python2(self, operation, timestamp, secret_access_key):
 		my_sha_hmac = hmac.new(secret_access_key, 'AWSMechanicalTurkRequester' + operation + timestamp, hashlib.sha1)
-		my_b64_hmac_digest = base64.encodestring(my_sha_hmac.digest()).strip()
+		my_b64_hmac_digest = base64.encodebytes(my_sha_hmac.digest()).strip()
 		return my_b64_hmac_digest
 
 	def _generate_signature_python3(self, operation, timestamp, secret_access_key):
 		key = bytearray(secret_access_key, 'utf-8')
 		msg = bytearray('AWSMechanicalTurkRequester' + operation + timestamp, 'utf-8')
 		my_sha_hmac = hmac.new(key, msg, hashlib.sha1)
-		my_b64_hmac_digest = base64.encodestring(my_sha_hmac.digest()).strip()
+		my_b64_hmac_digest = base64.encodebytes(my_sha_hmac.digest()).strip()
 		return str(my_b64_hmac_digest, 'utf-8')
 
 	def _generate_signature(self, operation, timestamp, secret_access_key):


### PR DESCRIPTION
encodestring is deprecated in Python 3 and results in a warning being logged on every call